### PR TITLE
Add description method and some comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 # Logs
 logs
 *.log

--- a/index.js
+++ b/index.js
@@ -8,11 +8,27 @@ module.exports = class TrailsModel {
     this.app = app
   }
 
+  /**
+   * Specific model configuration (override config/models.js)
+   * @return object config to merge with defaults
+   */
   static config () {
 
   }
 
+  /**
+   * Model schema in ORM specific structure (waterline, Bookshelf...)
+   * @return object schema
+   */
   static schema () {
+
+  }
+
+  /**
+   * Model description, can be use for documentation generator like swagger
+   * @return object
+   */
+  static description () {
 
   }
 


### PR DESCRIPTION
Related to https://github.com/trailsjs/trails-model/issues/1 like this swagger (or others) can have a description whatever the chosen ORM and swagger doesn't have to parse schema (witch differ with ORM) to generate models definitions
